### PR TITLE
PHPCompat: remove PHP4-style constructor

### DIFF
--- a/stp-importer.php
+++ b/stp-importer.php
@@ -172,10 +172,6 @@ class STP_Import extends WP_Importer {
 		echo '<p>' . __('Now wasn&#8217;t that easy?', 'stp-importer') . '</p>';
 		echo '</div>';
 	}
-
-	function STP_Import ( ) {
-		// Nothing.
-	}
 }
 
 // create the import object


### PR DESCRIPTION
PHP 4-style constructors where the constructor function name mirrors the class name have been deprecated since PHP 7.0 and support has been removed since PHP 8.0, which means they are now silently ignored.

Considering the constructor is empty and is overloading an equally [empty constructor in the `WP_Importer` class](https://developer.wordpress.org/reference/classes/wp_importer/), I'm fixing this by removing the method.

This should not be considered a BC-break as calling the constructor directly on an instantiated object was never the intention of the code anyway and instantiating the object via `new STP_Import()` will now fall through to the parent constructor, which equally does nothing anyway.

Refs:
* https://wiki.php.net/rfc/remove_php4_constructors