### PR TITLE
Update STP Importer to 0.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Plugin Name ===
 Contributors: wordpressdotorg
-Donate link: 
+Donate link:
 Tags: importer, simple tagging
 Requires at least: 3.0
-Tested up to: 4.1
+Tested up to: 6.2
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -25,6 +25,13 @@ Import Simple Tagging tags into WordPress tags.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3 =
+* Add support for WordPress 6.2
+
+= 0.2 =
+* Add WP_LOAD_IMPORTERS check
+* Add I18N for importers
 
 = 0.1 =
 * Initial release

--- a/stp-importer.php
+++ b/stp-importer.php
@@ -5,8 +5,8 @@ Plugin URI: http://wordpress.org/extend/plugins/stp-importer/
 Description: Import Simple Tagging tags into WordPress tags.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.2
-Stable tag: 0.2
+Version: 0.3
+Stable tag: 0.3
 License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/stp-importer.php
+++ b/stp-importer.php
@@ -33,7 +33,7 @@ class STP_Import extends WP_Importer {
 	function header()  {
 		echo '<div class="wrap">';
 
-		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+		if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 			screen_icon();
 		}
 


### PR DESCRIPTION
This PR upgrades the plugin to 0.3.

1. Tested with WordPress 6.1
2. Tested with PHP 7.4.33
3. https://github.com/WordPress/stp-importer/pull/1

How to test:
1. Clone the plugin
2. Spin a new docker image[^1]
3. Substitute `YOUR_FOLDER` with the path of the cloned plugin
4. Go to `http://localhost/wp-admin/plugins.php` and activate **Simple Tags Importer**
5. Install the [Simple Tagging plugin](http://plugins.svn.wordpress.org/simple-tagging-plugin/tags/1.6.2/)
6. Generate some content
7. Open `http://localhost/wp-admin/admin.php?import=stp`
8. Start import
9. The plugin must create all the new tags without errors

[^1]: `docker-compose.yml` file
```yaml
services:
  db:
    image: mariadb:latest
    command: '--default-authentication-plugin=mysql_native_password'
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      - MYSQL_ROOT_PASSWORD=somewordpress
      - MYSQL_DATABASE=wordpress
      - MYSQL_USER=wordpress
      - MYSQL_PASSWORD=wordpress
    expose:
      - 3306
      - 33060
  wordpress:
    image: wordpress:latest
    volumes:
      - wp_data:/var/www/html
      - YOUR_FOLDER:/var/www/html/wp-content/plugins/stp-importer
    ports:
      - 80:80
    restart: always
    environment:
      - WORDPRESS_DB_HOST=db
      - WORDPRESS_DB_USER=wordpress
      - WORDPRESS_DB_PASSWORD=wordpress
      - WORDPRESS_DB_NAME=wordpress
      - WORDPRESS_DEBUG=1
volumes:
  db_data:
  wp_data:
```
